### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lagoni/gh-action-asyncapi-document-bump",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lagoni/gh-action-asyncapi-document-bump",
-  "version": "0.3.11",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lagoni/gh-action-asyncapi-document-bump",
-      "version": "0.3.11",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoni/gh-action-asyncapi-document-bump",
   "description": "GitHub action for bumping version of AsyncAPI documents with semantic release",
-  "version": "0.3.11",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jonaslagoni/gh-action-asyncapi-document-bump.git"


### PR DESCRIPTION
Version bump in package.json for release [v0.4.0](https://github.com/jonaslagoni/gh-action-asyncapi-document-bump/releases/tag/v0.4.0)